### PR TITLE
Add support for UI extension

### DIFF
--- a/lib/rack/openid.rb
+++ b/lib/rack/openid.rb
@@ -7,6 +7,7 @@ require 'openid/extensions/sreg'
 require 'openid/extensions/ax'
 require 'openid/extensions/oauth'
 require 'openid/extensions/pape'
+require 'openid/extensions/ui'
 
 module Rack #:nodoc:
   # A Rack middleware that provides a more HTTPish API around the
@@ -125,6 +126,7 @@ module Rack #:nodoc:
           add_attribute_exchange_fields(oidreq, params)
           add_oauth_fields(oidreq, params)
           add_pape_fields(oidreq, params)
+          add_ui_fields(oidreq, params)
 
           url = open_id_redirect_url(req, oidreq, params)
           return redirect_to(url)
@@ -287,6 +289,13 @@ module Rack #:nodoc:
           preferred_auth_policies = preferred_auth_policies.split if preferred_auth_policies.is_a?(String)
           pape_request = ::OpenID::PAPE::Request.new(preferred_auth_policies || [], max_auth_age)
           oidreq.add_extension(pape_request)
+        end
+      end
+
+      def add_ui_fields(oidreq, fields)
+        if fields['ui[mode]'] || fields['ui[icon]'] || fields['ui[lang]']
+          uireq = ::OpenID::UI::Request.new(fields['ui[mode]'], fields['ui[icon]'], fields['ui[lang]'])
+          oidreq.add_extension(uireq)
         end
       end
 

--- a/test/test_openid.rb
+++ b/test/test_openid.rb
@@ -328,7 +328,7 @@ describe "openid" do
 
   def test_with_ui_icon
     @app = app(
-      :'ui[icon]' => 'http://example.com/favicon.png'
+      :'ui[icon]' => true
     )
     process('/', :method => 'GET')
 

--- a/test/test_openid.rb
+++ b/test/test_openid.rb
@@ -310,6 +310,54 @@ describe "openid" do
     assert_equal 200, @response.status
   end
 
+  def test_with_ui_mode
+    @app = app(
+      :'ui[mode]' => 'popup'
+    )
+    process('/', :method => 'GET')
+
+    location = @response.headers['Location']
+    assert_match(/openid.ui.mode/, location)
+
+    follow_redirect!
+    assert_equal 200, @response.status
+    assert_equal 'GET', @response.headers['X-Method']
+    assert_equal '/', @response.headers['X-Path']
+    assert_equal 'success', @response.body
+  end
+
+  def test_with_ui_icon
+    @app = app(
+      :'ui[icon]' => 'http://example.com/favicon.png'
+    )
+    process('/', :method => 'GET')
+
+    location = @response.headers['Location']
+    assert_match(/openid.ui.icon/, location)
+
+    follow_redirect!
+    assert_equal 200, @response.status
+    assert_equal 'GET', @response.headers['X-Method']
+    assert_equal '/', @response.headers['X-Path']
+    assert_equal 'success', @response.body
+  end
+
+  def test_with_ui_lang
+    @app = app(
+      :'ui[lang]' => 'ja-JP'
+    )
+    process('/', :method => 'GET')
+
+    location = @response.headers['Location']
+    assert_match(/openid.ui.lang/, location)
+
+    follow_redirect!
+    assert_equal 200, @response.status
+    assert_equal 'GET', @response.headers['X-Method']
+    assert_equal '/', @response.headers['X-Path']
+    assert_equal 'success', @response.body
+  end
+
   def test_with_missing_id
     @app = app(:identifier => "#{RotsServerUrl}/john.doe")
     process('/', :method => 'GET')


### PR DESCRIPTION
This PR adds support for the OpenID UI extension, originally committed to @nov's fork.

This branch is rebased off my pape branch that has already been submitted as a PR at grosser/rack-openid#1. It should not be merged before that PR.